### PR TITLE
No External Link Checking

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -29,7 +29,6 @@ jobs:
         set -ex
         hugo
     - name: Check links
-      if: github.ref != 'refs/heads/main'
       run: |
         set -ex
         htmltest

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -2,3 +2,4 @@ DirectoryPath: "public/"
 IgnoreInternalEmptyHash: true
 IgnoreAltMissing: true
 ExternalTimeout: 30
+CheckExternal: false


### PR DESCRIPTION
Disable external link checking to make the CI pass more than 20% of the time.